### PR TITLE
Remove timed out vehicles from VehicleDataCache (configurable)

### DIFF
--- a/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/core/AvlProcessor.java
@@ -246,6 +246,27 @@ public class AvlProcessor {
 	}
 
 	/**
+	 * Marks the vehicle as not being predictable and that the assignment has
+	 * been grabbed. Updates VehicleDataCache. Creates and logs a VehicleEvent
+	 * explaining the situation.
+	 * 
+	 * @param vehicleState
+	 *            The vehicle to be made unpredictable
+	 * @param eventDescription
+	 *            A longer description of why vehicle being made unpredictable
+	 * @param vehicleEvent
+	 *            A short description from VehicleEvent class for labeling the
+	 *            event.
+	 */
+	public void makeVehicleUnpredictableAndRemoveFromVehicleDataCache(
+			String vehicleId, String eventDescription, String vehicleEvent) {
+		makeVehicleUnpredictable(vehicleId, eventDescription, vehicleEvent);
+
+		// Remove vehicle from VehicleDataCache
+		VehicleDataCache.getInstance().removeVehicle(vehicleId);
+	}
+	
+	/**
 	 * Looks at the previous AVL reports to determine if vehicle is actually
 	 * moving. If it is not moving then the vehicle is made unpredictable. Uses
 	 * the system properties transitclock.core.timeForDeterminingNoProgress and

--- a/transitclock/src/main/java/org/transitclock/core/dataCache/VehicleDataCache.java
+++ b/transitclock/src/main/java/org/transitclock/core/dataCache/VehicleDataCache.java
@@ -539,4 +539,15 @@ public class VehicleDataCache {
 		updateVehicleIdsByBlockMap(originalVehicle, vehicle);
 		updateVehiclesMap(vehicle);
 	}
+
+	/**
+	 * Removes a vehicle from the vehiclesMap
+	 * 
+	 * @param vehicleId
+	 *            The id of the vehicle to remove from the vehiclesMap
+	 */
+	public void removeVehicle(String vehicleId) {
+		logger.debug("Removing from VehicleDataCache vehiclesMap vehicleId={}", vehicleId);
+		vehiclesMap.remove(vehicleId);
+	}
 }


### PR DESCRIPTION
Add a configuration option and supporting methods to the TimeoutHandlerModule that allows timed out vehicles to be not only marked unpredictable, but also removed from the VehicleDataCache.

-- Add new config param, `transitclock.timeout.removeTimedOutVehiclesFromVehicleDataCache` that defaults to false (retains existing behavior)
-- Add new public method `VehicleDataCache::removeVehicle`. Currently this only removes the vehicle from the vehiclesMap cache. There are additional caches in VehicleDataCache, but vehiclesMap is the one that is used for constructing feeds, and is the only other case of removing vehicles (schedule based vehicles)
-- Add new public method `AvlProcessor::makeVehicleUnpredictableAndRemoveFromVehicleDataCache`

Motivation:
Since we're using a geofence on our input GTFS Realtime feed, prior to TheTransitClock, we don't get continuous AVL updates. When the vehicle leaves the geofence, it's location is still cached, so it can appear "stuck" within TheTransitClock. It also stays in the output GTFS Realtime vehicle positions feed, which causes two warnings in Google Transit: `VEHICLE_POSITION_TIMESTAMP_CONSISTENTLY_IN_THE_PAST` and `INVALID_VEHICLE_POSITION_STALE_TIMESTAMP`

More background: https://app.asana.com/0/823070910792882/825318910270240